### PR TITLE
Cheffile and Vagrantfile updates, especially setting specific cookbook versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/.vagrant/
+/Cheffile.lock
+/cookbooks/
+/public/ca.crt
+/public/client.crt
+/public/client.key
+/public/jnl-elife.sql.gz
+/public/settings.php
+/public/ta.key
+/tmp/

--- a/Cheffile
+++ b/Cheffile
@@ -4,30 +4,24 @@
 site 'http://community.opscode.com/api/v1'
 
 # basics for drupal
-cookbook 'apache2'
-cookbook 'apt'
-cookbook 'git'
-cookbook 'build-essential'
-cookbook 'memcached'
-cookbook 'mysql'
-cookbook 'openssl'
-cookbook 'php', :git => 'git@github.com:elifesciences/chef-opscode-php.git' # use until pull request is accepted https://github.com/opscode-cookbooks/php/pull/54
-cookbook 'varnish'
-cookbook 'hosts'
-cookbook 'phpmyadmin' # from user priestjim on github
+cookbook 'apache2', '=1.10.0'
+cookbook 'apt', '=2.3.8'
+cookbook 'git', '=4.0.0'
+cookbook 'build-essential', '=1.4.4'
+cookbook 'memcached', '=1.7.2'
+cookbook 'mysql', '=4.1.2'
+cookbook 'openssl', '=1.1.0'
+cookbook 'php', '=1.4.6'
+cookbook 'varnish', '=0.9.12'
+cookbook 'hosts', '=0.1.1'
+cookbook 'phpmyadmin', '=1.0.6'    # from user priestjim on github
 
-cookbook 'openvpnc', :git => 'git@github.com:rivimey/openvpnc.git'
+cookbook 'openvpnc', '=2.1.0', :git => 'git@github.com:rivimey/openvpnc.git'
 
 # elife drupal module git repos, and highwire drupal base site
-cookbook 'drupal-site-jnl-elife-cookbook', :git => 'git@github.com:elifesciences/drupal-site-jnl-elife-cookbook.git'
+cookbook 'drupal-site-jnl-elife-cookbook', '=0.2.2', :git => 'git@github.com:elifesciences/drupal-site-jnl-elife-cookbook.git'
 
 # elife modified cookbooks for drupal installation
-cookbook 'elife-drupal-cookbook', :git => 'git@github.com:elifesciences/elife-drupal-cookbook.git'
+cookbook 'elife-drupal-cookbook', '=0.3.0', :git => 'git@github.com:elifesciences/elife-drupal-cookbook.git'
 
-cookbook 'elife-drush-cookbook', :git => 'git@github.com:elifesciences/elife-drush-cookbook.git'
-
-# - hosts
-# - phpmyadmin
-
-# TODOs
-# - provide specific versions for community cookbooks
+cookbook 'elife-drush-cookbook', '=0.9.1', :git => 'git@github.com:elifesciences/elife-drush-cookbook.git'

--- a/Cheffile
+++ b/Cheffile
@@ -19,7 +19,7 @@ cookbook 'phpmyadmin', '=1.0.6'    # from user priestjim on github
 cookbook 'openvpnc', '=2.1.0', :git => 'git@github.com:rivimey/openvpnc.git'
 
 # elife drupal module git repos, and highwire drupal base site
-cookbook 'drupal-site-jnl-elife-cookbook', '=0.2.2', :git => 'git@github.com:elifesciences/drupal-site-jnl-elife-cookbook.git'
+cookbook 'drupal-site-jnl-elife-cookbook', :git => 'git@github.com:elifesciences/drupal-site-jnl-elife-cookbook.git'
 
 # elife modified cookbooks for drupal installation
 cookbook 'elife-drupal-cookbook', '=0.3.0', :git => 'git@github.com:elifesciences/elife-drupal-cookbook.git'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,7 +90,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
 
     # Install latest version of Chef
-    override.omnibus.chef_version = :latest
+    override.omnibus.chef_version = "11.12.0"
 
     aws.access_key_id = ENV['AWS_KEY_ID']
     aws.secret_access_key = ENV['AWS_SECRET_KEY']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -105,7 +105,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.instance_type = "m1.large"
     aws.security_groups = [ "default-vpn" ]
 
-    aws.ami = "ami-de0d9eb7"
+    aws.ami = "ami-2f8f9246"
     aws.region = "us-east-1"
 
     override.ssh.username = "ubuntu"
@@ -149,10 +149,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Set this to :debug if you want more debugging info, else :info or :warn
     chef.log_level = :info
 
-    # this installs most of the infrastrucutre required to support a drupal instance
-    chef.add_recipe "apt" # add this so we have updated packages available
-    chef.add_recipe "git"
-
     # This represents our default Drupal development stack.
     chef.add_recipe "elife-drupal-cookbook::drupal_lamp_dev"
 
@@ -193,6 +189,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         "hiwire_rev" => "7.x-1.x-stable",
         "webroot_rev" => "7.x-1.x-stable",
         "setup_vpn_client" => ELIFE_CONFIGURE_OPENVPN
+      },
+      "apt" => {
+        "periodic_update_min_delay" => 720,
       }
     }
 


### PR DESCRIPTION
 - To avoid unexpected issues a consistent set of cookbook versions is being used.
    -- the mysql cookbook is 'derated' from the current 5.1.0 to 4.1.2 because in the 5.x series a bunch of additional configuration is needed. Updating to 5.1.x permits newer cookbooks elsewhere as well.

 - The AMI id used for AWS is updated to a standard version of Ubuntu 12.04 that includes the openssl fixes from 8th April. This version, like the last, uses temporary file storage, not EBS

 - I have removed the explicit use of elifesciences php cookbook because the bug referenced (https://github.com/opscode-cookbooks/php/pull/54) has been committed to mainstream.

 - The JSON block includes a setting for the 'apt' cookbook so that it will check for updates no sooner than 10 minutes, not 24 hours, to workaround an issue with important updates.

 - I have added a gitignore file for the common additional files.

I have tested this file on two AWS builds and it all seems good!

Note
====
There is a message output at the start of the run, containing:

    ''SSL validation of HTTPS requests is disabled. HTTPS connections are still
encrypted, but chef is not able to detect forged replies or man in the middle
attacks.''

I presume this is a new thing added to cookbooks recently. While it should probably be looked into it doesn't stop the build working and shouldn't affect our work.